### PR TITLE
Accept for date formats (logback patterns) in logfiles

### DIFF
--- a/montecristo/src/main/kotlin/com/datastax/montecristo/logs/LogEntry.kt
+++ b/montecristo/src/main/kotlin/com/datastax/montecristo/logs/LogEntry.kt
@@ -47,16 +47,14 @@ class LogEntry(
                     val level = groups?.get(logRegex.groupMappings.getOrDefault(LogEntryGroupings.LEVEL, 1))?.value ?: ""
                     val isoFormatDate = groups?.get(logRegex.groupMappings.getOrDefault(LogEntryGroupings.DATE, 2))?.value?.trim()
 
-                    if (level == "" || isoFormatDate == "") {
+                    if (level == "" || isoFormatDate.isNullOrBlank()) {
                         return LogEntry("", "", "")
                     }
-                    val parsedDate = SimpleDateFormat("yyyy-MM-dd HH:mm:ss").parse(isoFormatDate)
+                    // logback's %date may use either a space or a 'T' between the date and time
+                    val parsedDate = SimpleDateFormat("yyyy-MM-dd HH:mm:ss").parse(isoFormatDate.replace('T', ' '))
                     val timestamp = SimpleDateFormat(internalFormat).format(parsedDate)
 
                     val message = groups?.get(logRegex.groupMappings.getOrDefault(LogEntryGroupings.MESSAGE, 3))?.value?.trim()
-                    if (isoFormatDate.isNullOrBlank()) {
-                        logger.info("BLANK TIMESTAMP : $line")
-                    }
                     return LogEntry(level, message, timestamp)
                 } else {
                     val groups = alt_regex1.find(line)?.groups

--- a/montecristo/src/main/kotlin/com/datastax/montecristo/logs/LogRegex.kt
+++ b/montecristo/src/main/kotlin/com/datastax/montecristo/logs/LogRegex.kt
@@ -51,17 +51,25 @@ data class LogRegex(val regex: Regex, val groupMappings: Map<LogEntryGroupings, 
                 val potentialRegex = logbackPattern
                     .replace("%-5level", "(\\w+)")
                     .replace("[%thread]", "\\[.*?]")
-                    .replace("%date{ISO8601}", "([^,]*),\\d*")
+                    .replace(Regex("%date\\{[^}]*\\}"), "([^.,]+)(?:[.,][a-zA-Z_0-9]+)?")
                     .replace("%X{service}", "" ) // becomes a part of the message
                     .replace("%F:%L - %msg%n", "(.*)")
                     .replace("%F:%L %M %msg%n", "(.*)")
                     .replace("%marker", "") // becomes part of the message
                     .replace(" ","\\s*")
 
-                // now need to understand, the order of the groupings
-                val levelPosition = potentialRegex.substringBefore("(\\w+)").filter { it == '('}.count() + 1
-                val datePosition = potentialRegex.substringBefore("([^,]*),\\d*").filter { it == '('}.count() + 1
-                val messagePosition = potentialRegex.substringBefore( "(.*)").filter { it == '('}.count() + 1
+                // Work out the order (1-based index) of the capturing groups. We count the
+                // opening parens that precede each group's marker, skipping the non-capturing
+                // "(?:...)" group introduced by the optional sub-second fraction of the date.
+                val levelPosition = potentialRegex.substringBefore("(\\w+)")
+                    .filterIndexed { i, ch -> ch == '(' && !potentialRegex.startsWith("(?:", i)}.count() + 1
+
+                val datePosition = potentialRegex.substringBefore("([^.,]+)")
+                    .filterIndexed { i, ch -> ch == '(' && !potentialRegex.startsWith("(?:", i)}.count() + 1
+
+                val messagePosition = potentialRegex.substringBefore( "(.*)")
+                    .filterIndexed { i, ch -> ch == '(' && !potentialRegex.startsWith("(?:", i)}.count() + 1
+
                 val groupMappings = mapOf(
                     LogEntryGroupings.LEVEL to levelPosition,
                     LogEntryGroupings.DATE to datePosition,

--- a/montecristo/src/test/kotlin/com/datastax/montecristo/logs/LogEntryTest.kt
+++ b/montecristo/src/test/kotlin/com/datastax/montecristo/logs/LogEntryTest.kt
@@ -1,0 +1,101 @@
+/*
+ * Copyright DataStax, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.datastax.montecristo.logs
+
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.Test
+import java.time.LocalDateTime
+
+class LogEntryTest {
+
+    // The default logback pattern, which LogRegex.convert short-circuits to defaultRegex().
+    private val defaultPattern = "%-5level [%thread] %date{ISO8601} %F:%L - %msg%n"
+
+    @Test
+    fun testFromStringParsesDefaultPattern() {
+        // Given a standard Cassandra log line (ISO8601 date with comma-separated millis)
+        val line =
+            "WARN  [SharedPool-Worker-1] 2020-09-03 10:25:03,316 ReadCommand.java:520 - Read 61 live rows"
+        // When parsing with the regex derived from the default logback pattern
+        val regex = LogRegex.convert(defaultPattern)
+        val entry = LogEntry.fromString(line, regex)
+        // Then the level, normalised timestamp and message are extracted
+        assertThat(entry.level).isEqualTo("WARN")
+        assertThat(entry.timestamp).isEqualTo("20200903102503")
+        assertThat(entry.message).isEqualTo("ReadCommand.java:520 - Read 61 live rows")
+    }
+
+    @Test
+    fun testFromStringAcceptsTDelimiter() {
+        // Given a log line whose date uses a 'T' between date and time (ISO8601 variant)
+        val line =
+            "ERROR [main] 2021-12-31T23:59:59,001 Startup.java:42 - boom"
+        val regex = LogRegex.convert(defaultPattern)
+        // When parsing
+        val entry = LogEntry.fromString(line, regex)
+        // Then the 'T' is normalised away and the timestamp parses correctly
+        assertThat(entry.level).isEqualTo("ERROR")
+        assertThat(entry.timestamp).isEqualTo("20211231235959")
+    }
+
+    @Test
+    fun testFromStringAcceptsDottedMillis() {
+        // Given a non-default pattern whose date format uses a '.' before the sub-second value
+        val pattern = "%-5level [%thread] %date{yyyy-MM-dd HH:mm:ss.SSS} %F:%L - %msg%n"
+        val line =
+            "INFO  [GossipStage:1] 2022-06-01 08:15:30.742 Gossiper.java:101 - node up"
+        val regex = LogRegex.convert(pattern)
+        // When parsing
+        val entry = LogEntry.fromString(line, regex)
+        // Then both the dotted fraction and the message are handled
+        assertThat(entry.level).isEqualTo("INFO")
+        assertThat(entry.timestamp).isEqualTo("20220601081530")
+        assertThat(entry.message).isEqualTo("Gossiper.java:101 - node up")
+    }
+
+    @Test
+    fun testFromStringReturnsEmptyForBlankLine() {
+        // Given a blank line
+        val regex = LogRegex.convert(defaultPattern)
+        // When parsing
+        val entry = LogEntry.fromString("   ", regex)
+        // Then an empty LogEntry is returned (no level, no timestamp)
+        assertThat(entry.level).isEqualTo("")
+        assertThat(entry.timestamp).isEqualTo("")
+    }
+
+    @Test
+    fun testFromStringReturnsEmptyForUnparseableLine() {
+        // Given a line that matches neither the primary nor the fallback regex
+        val regex = LogRegex.convert(defaultPattern)
+        // When parsing
+        val entry = LogEntry.fromString("not a log line at all", regex)
+        // Then an empty LogEntry is returned rather than throwing
+        assertThat(entry.level).isEqualTo("")
+        assertThat(entry.timestamp).isEqualTo("")
+    }
+
+    @Test
+    fun testGetDateReturnsLocalDateTime() {
+        // Given a LogEntry with an internal-format timestamp
+        val entry = LogEntry("DEBUG", "dummy", "20250824123045")
+        // When converting the timestamp to a LocalDateTime
+        val actual = entry.getDate()
+        // Then it matches the expected date/time
+        assertThat(actual).isEqualTo(LocalDateTime.of(2025, 8, 24, 12, 30, 45))
+    }
+}

--- a/montecristo/src/test/kotlin/com/datastax/montecristo/logs/LogRegexTest.kt
+++ b/montecristo/src/test/kotlin/com/datastax/montecristo/logs/LogRegexTest.kt
@@ -1,0 +1,71 @@
+/*
+ * Copyright DataStax, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.datastax.montecristo.logs
+
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.Test
+
+class LogRegexTest {
+
+    @Test
+    fun testDefaultPatternShortCircuitsToDefaultRegex() {
+        // Given the canonical logback pattern
+        val regex = LogRegex.convert("%-5level [%thread] %date{ISO8601} %F:%L - %msg%n")
+        // Then the default group mapping is used (level=1, date=2, message=3)
+        assertThat(regex.groupMappings[LogEntryGroupings.LEVEL]).isEqualTo(1)
+        assertThat(regex.groupMappings[LogEntryGroupings.DATE]).isEqualTo(2)
+        assertThat(regex.groupMappings[LogEntryGroupings.MESSAGE]).isEqualTo(3)
+    }
+
+    @Test
+    fun testConvertKeepsGroupOrderForStandardLayout() {
+        // Given a non-default pattern that still lists level, date then message
+        val regex = LogRegex.convert("%-5level [%thread] %date{yyyy-MM-dd HH:mm:ss.SSS} %F:%L - %msg%n")
+        // Then the group positions reflect that order, skipping the non-capturing fraction group
+        assertThat(regex.groupMappings[LogEntryGroupings.LEVEL]).isEqualTo(1)
+        assertThat(regex.groupMappings[LogEntryGroupings.DATE]).isEqualTo(2)
+        assertThat(regex.groupMappings[LogEntryGroupings.MESSAGE]).isEqualTo(3)
+    }
+
+    @Test
+    fun testConvertTracksReorderedGroups() {
+        // Given a pattern where the date comes before the level
+        val regex = LogRegex.convert("%date{ISO8601} %-5level [%thread] %F:%L - %msg%n")
+        // Then the computed positions follow the new ordering
+        assertThat(regex.groupMappings[LogEntryGroupings.DATE]).isEqualTo(1)
+        assertThat(regex.groupMappings[LogEntryGroupings.LEVEL]).isEqualTo(2)
+        assertThat(regex.groupMappings[LogEntryGroupings.MESSAGE]).isEqualTo(3)
+    }
+
+    @Test
+    fun testConvertedRegexMatchesCommaMillisLine() {
+        // Given a converted regex from a reordered pattern
+        val regex = LogRegex.convert("%date{ISO8601} %-5level [%thread] %F:%L - %msg%n")
+        val line = "2020-09-03 10:25:03,316 WARN [SharedPool-1] ReadCommand.java:520 - Read 61 live rows"
+        // Then it matches the corresponding log line
+        assertThat(regex.regex.matches(line)).isTrue()
+    }
+
+    @Test
+    fun testConvertedRegexMatchesDottedMillisLine() {
+        // Given a pattern whose date format separates sub-seconds with a '.'
+        val regex = LogRegex.convert("%-5level [%thread] %date{yyyy-MM-dd HH:mm:ss.SSS} %F:%L - %msg%n")
+        val line = "INFO [GossipStage:1] 2022-06-01 08:15:30.742 Gossiper.java:101 - node up"
+        // Then the line matches
+        assertThat(regex.regex.matches(line)).isTrue()
+    }
+}


### PR DESCRIPTION
In `logback.xm`l the appender's pattern can contain variations of `%date{…}`

Loosen the regexp translation of this, and accept either a space or 'T' character deliminator between the date and time.