### PR TITLE
Initial draft - this adds parsing of unit capability to the yaml parser

### DIFF
--- a/montecristo/src/main/kotlin/com/datastax/montecristo/fileLoaders/parsers/application/CassandraYamlParser.kt
+++ b/montecristo/src/main/kotlin/com/datastax/montecristo/fileLoaders/parsers/application/CassandraYamlParser.kt
@@ -20,6 +20,11 @@ import com.fasterxml.jackson.databind.ObjectMapper
 import com.fasterxml.jackson.dataformat.yaml.YAMLFactory
 import com.datastax.montecristo.model.application.CassandraYaml
 import java.io.File
+import org.yaml.snakeyaml.Yaml
+import org.yaml.snakeyaml.nodes.MappingNode
+import org.yaml.snakeyaml.nodes.Node
+import org.yaml.snakeyaml.nodes.ScalarNode
+import org.yaml.snakeyaml.nodes.SequenceNode
 
 object CassandraYamlParser {
 
@@ -32,6 +37,31 @@ object CassandraYamlParser {
         val obj = yamlReader.readValue(data, Any::class.java)
         val jsonWriter = ObjectMapper()
         val json = jsonWriter.readTree(jsonWriter.writeValueAsString(obj))
-        return CassandraYaml(json)
+        return CassandraYaml(json, buildLineMap(data))
+    }
+
+    private fun buildLineMap(data: String): Map<String, Int> {
+        val root = Yaml().compose(data.reader()) ?: return emptyMap()
+        val lineNumbers = mutableMapOf<String, Int>()
+        walk(root, "", lineNumbers)
+        return lineNumbers
+    }
+
+    private fun walk(node: Node, path: String, lineNumbers: MutableMap<String, Int>) {
+        when (node) {
+            is MappingNode -> {
+                node.value.forEach { tuple ->
+                    val key = (tuple.keyNode as? ScalarNode)?.value ?: return@forEach
+                    val childPath = if (path.isEmpty()) key else "$path.$key"
+                    lineNumbers.putIfAbsent(childPath, tuple.keyNode.startMark.line + 1)
+                    walk(tuple.valueNode, childPath, lineNumbers)
+                }
+            }
+            is SequenceNode -> {
+                // Keep path semantics aligned with YamlConfig.getValueFromPath by following first element.
+                node.value.firstOrNull()?.let { walk(it, path, lineNumbers) }
+            }
+            else -> Unit
+        }
     }
 }

--- a/montecristo/src/main/kotlin/com/datastax/montecristo/helpers/ByteCountHelper.kt
+++ b/montecristo/src/main/kotlin/com/datastax/montecristo/helpers/ByteCountHelper.kt
@@ -16,6 +16,7 @@
 
 package com.datastax.montecristo.helpers
 
+import com.datastax.montecristo.model.application.ParsedByteCount
 import java.math.BigDecimal
 import java.util.*
 import kotlin.math.ln
@@ -54,25 +55,59 @@ object ByteCountHelper {
         var returnValue: Long = -1
         val parserPattern = Regex("([\\d. ]+)([EPTGMKk])(i?B)")
         if (parserPattern.matches(textSize)) {
+
             val number = parserPattern.find(textSize)!!.groups[1]!!.value.toDouble()
-            val pow = when (parserPattern.find(textSize)!!.groups[2]!!.value) {
-                "E" -> 6
-                "P" -> 5
-                "T" -> 4
-                "G" -> 3
-                "M" -> 2
-                "k", "K" -> 1
-                else -> 0
-            }
-            val base: Long = when (parserPattern.find(textSize)!!.groups[3]!!.value) {
-                "B" -> 1000     // SI (decimal) units
-                "iB" -> 1024    // Binary units
-                else -> 0
-            }
+            val prefix = parserPattern.find(textSize)!!.groups[2]!!.value
+            val binaryMarker = parserPattern.find(textSize)!!.groups[3]!!.value
+            val pow = convertPrefix(prefix)
+            val base: Long = convertBinaryMarker(binaryMarker)
             var bytes = BigDecimal(number)
             bytes = bytes.multiply(BigDecimal.valueOf(base).pow(pow))
             returnValue = bytes.toLong()
         }
         return returnValue
+    }
+
+    fun parseByteCountWithRate(rateString: String): ParsedByteCount {
+        // Parses strings like "MB/s", "MiB/s", "GiB/s", "GB/s" and returns the numeric value and unit without the rate suffix
+        // Pattern: number + unit (with optional prefix and i for binary) + optional /s or /sec
+        val parserPattern = Regex("([\\d. ]+)\\s*([EPTGMKk])(i?B)(?:/s)?(?:/sec)?", RegexOption.IGNORE_CASE)
+        val match = parserPattern.find(rateString) ?: return ParsedByteCount(-1, "Invalid format")
+
+        val number = match.groups[1]!!.value.toDouble()
+        val prefix = match.groups[2]!!.value
+        val binaryMarker = match.groups[3]!!.value
+
+        val pow = convertPrefix(prefix)
+        val base: Long = convertBinaryMarker(binaryMarker)
+        var bytes = BigDecimal(number)
+        bytes = bytes.multiply(BigDecimal.valueOf(base).pow(pow))
+
+        // Reconstruct the unit without the /s suffix
+        val unit = prefix + binaryMarker
+
+        return ParsedByteCount(bytes.toLong(), unit)
+    }
+
+    private fun convertBinaryMarker(binaryMarker: String): Long {
+        val base: Long = when (binaryMarker) {
+            "B" -> 1000     // SI (decimal) units
+            "iB" -> 1024    // Binary units
+            else -> 0
+        }
+        return base
+    }
+
+    private fun convertPrefix(prefix: String): Int {
+        val pow = when (prefix) {
+            "E" -> 6
+            "P" -> 5
+            "T" -> 4
+            "G" -> 3
+            "M" -> 2
+            "k", "K" -> 1
+            else -> 0
+        }
+        return pow
     }
 }

--- a/montecristo/src/main/kotlin/com/datastax/montecristo/model/Cluster.kt
+++ b/montecristo/src/main/kotlin/com/datastax/montecristo/model/Cluster.kt
@@ -16,6 +16,7 @@
 
 package com.datastax.montecristo.model
 
+import com.datastax.montecristo.helpers.ByteCountHelper
 import com.datastax.montecristo.helpers.Utils
 import com.datastax.montecristo.metrics.IMetricServer
 import com.datastax.montecristo.model.application.ConfigValue
@@ -35,6 +36,8 @@ data class Cluster(val nodes: List<Node>,
                    val metricServer: IMetricServer,
                    val loadErrors: MutableList<LoadError>) {
 
+    private data class SelectedConfigValue(val configSetting: String, val value: String, val isLegacy: Boolean, val defaultValue: String, val defaultUnits: String)
+
     // config helpers
     fun getSetting(configSetting: String, configSource: ConfigSource, default: String = "", isList: Boolean = false): ConfigurationSetting {
         val values = // If config setting is commented, it'll get the default value
@@ -43,13 +46,90 @@ data class Cluster(val nodes: List<Node>,
                 val yaml = if (configSource == ConfigSource.CASS) node.cassandraYaml else node.dseYaml
                 val foundValue = yaml.get(configSetting, "not_set", isList)
                 if (foundValue == "not_set") {
-                    Pair(node.hostname, ConfigValue(false, default, ""))
+                    Pair(node.hostname, ConfigValue( false, default,"","", configSetting))
                 } else {
-                    Pair(node.hostname, ConfigValue(true, default, foundValue))
+                    Pair(node.hostname, ConfigValue (true, default, foundValue, "", configSetting,))
                 }
             }
 
             return ConfigurationSetting(name = configSetting, values = values)
+    }
+
+    fun getSetting(configSource: ConfigSource,
+                   configSetting: String,
+                   defaultValue: String = "",
+                   defaultUnits: String="",
+                   legacyConfigSetting: String,
+                   legacyDefaultValue: String = "",
+                   legacyDefaultUnits: String="",
+                   isList: Boolean = false): ConfigurationSetting {
+        val values = // If config setting is commented, it'll get the default value
+            nodes.associate { node ->
+                val yaml = if (configSource == ConfigSource.CASS) node.cassandraYaml else node.dseYaml
+                val currentValue = yaml.get(configSetting, "not_set", isList)
+                val legacyValue = yaml.get(legacyConfigSetting, "not_set", isList)
+                val currentConfigValue = SelectedConfigValue(configSetting, currentValue, isLegacy = false, defaultValue, defaultUnits)
+                val legacyConfigValue = SelectedConfigValue(legacyConfigSetting, legacyValue, isLegacy = true, legacyDefaultValue, legacyDefaultUnits)
+
+                val selectedConfig = selectSettingValue(yaml, currentConfigValue,legacyConfigValue, this.databaseVersion.hasUnitYamlValues())
+                if (selectedConfig == null) {
+                    Pair(node.hostname, ConfigValue(false, legacyDefaultValue, "", legacyDefaultUnits, configSetting))
+                } else if (legacyDefaultUnits.isNotEmpty()) {
+                    val valueToParse = if (selectedConfig.isLegacy) {
+                        // Add units to legacy values so they can be parsed like modern unit-bearing values.
+                        "${selectedConfig.value} $legacyDefaultUnits"
+                    } else {
+                        selectedConfig.value
+                    }
+                    parseSetting(selectedConfig.configSetting, valueToParse, node.hostname, legacyDefaultValue, legacyDefaultUnits)
+                } else {
+                    Pair(node.hostname, ConfigValue( true, legacyDefaultValue, selectedConfig.value, legacyDefaultUnits, selectedConfig.configSetting))
+                }
+            }
+        // could be a mix of config names used here, but in the report we are only going to mention the first one.
+        return ConfigurationSetting(name = values.firstNotNullOf{c -> c.value.configSetting}, values = values)
+    }
+
+    private fun selectSettingValue(
+        yaml: com.datastax.montecristo.model.application.YamlConfig,
+        currentConfigValue: SelectedConfigValue,
+        legacyConfigValue: SelectedConfigValue,
+        supportsUnitValues : Boolean
+    ): SelectedConfigValue? {
+        val hasCurrent = currentConfigValue.value != "not_set"
+        val hasLegacy = legacyConfigValue.value != "not_set"
+
+        return when {
+            !hasCurrent && !hasLegacy -> null
+            !supportsUnitValues -> legacyConfigValue
+            hasCurrent && !hasLegacy -> currentConfigValue
+            !hasCurrent && hasLegacy -> legacyConfigValue
+            else -> {
+                val currentLineNumber = yaml.lineFor(currentConfigValue.configSetting)
+                val legacyLineNumber = yaml.lineFor(legacyConfigValue.configSetting)
+                if (currentLineNumber == null || legacyLineNumber == null || currentLineNumber >= legacyLineNumber) {
+                    currentConfigValue
+                } else {
+                    legacyConfigValue
+                }
+            }
+        }
+    }
+
+    private fun parseSetting(
+        configSetting: String,
+        valueFound: String,
+        hostName: String,
+        defaultValue: String,
+        defaultUnits: String,
+    ): Pair<String, ConfigValue> {
+        // are we expecting this setting to have units? (and does the DB even support them? ignore if it doesn't
+        if (defaultUnits != "") {
+            val parsedConfig = ByteCountHelper.parseByteCountWithRate(valueFound)
+            return Pair(hostName, ConfigValue( true, defaultValue, parsedConfig.bytes.toString(), parsedConfig.unit, configSetting))
+        } else {
+            return Pair(hostName, ConfigValue( true, defaultValue, valueFound, defaultUnits, configSetting))
+        }
     }
 
     fun getNode(nodeName : String) : Node? {

--- a/montecristo/src/main/kotlin/com/datastax/montecristo/model/application/CassandraYaml.kt
+++ b/montecristo/src/main/kotlin/com/datastax/montecristo/model/application/CassandraYaml.kt
@@ -18,7 +18,10 @@ package com.datastax.montecristo.model.application
 
 import com.fasterxml.jackson.databind.JsonNode
 
-data class CassandraYaml(val data : JsonNode)  : YamlConfig(data) {
+data class CassandraYaml(
+    val data : JsonNode,
+    val lines: Map<String, Int> = emptyMap()
+)  : YamlConfig(data, lines) {
 
     // helpers for specific properties
     val clusterName get() = getValueFromPath("cluster_name", "")
@@ -26,8 +29,6 @@ data class CassandraYaml(val data : JsonNode)  : YamlConfig(data) {
     val seeds get() = getValueFromPath("seed_provider.parameters.seeds", "unknown")
     val listenAddress get() = getValueFromPath("listen_address","")
     val broadcastAddress get() = getValueFromPath("broadcast_address","")
-    val compactionThroughputLegacy get() = get("compaction_throughput_mb_per_sec")
-    val compactionThroughput get() = get("compaction_throughput")
     val concurrentCompactors get() = get("concurrent_compactors")
     val partitioner get() = get("partitioner")
     val memtableAllocationType get() = get("memtable_allocation_type")

--- a/montecristo/src/main/kotlin/com/datastax/montecristo/model/application/ConfigValue.kt
+++ b/montecristo/src/main/kotlin/com/datastax/montecristo/model/application/ConfigValue.kt
@@ -16,7 +16,7 @@
 
 package com.datastax.montecristo.model.application
 
-data class ConfigValue (val isSet : Boolean, val defaultValue : String, val value : String) {
+data class ConfigValue (val isSet : Boolean, val defaultValue : String, val value : String, val units : String = "", val configSetting: String = "") {
 
     fun getConfigValue() : String {
         return if (isSet) {

--- a/montecristo/src/main/kotlin/com/datastax/montecristo/model/application/ParsedByteCount.kt
+++ b/montecristo/src/main/kotlin/com/datastax/montecristo/model/application/ParsedByteCount.kt
@@ -1,0 +1,4 @@
+package com.datastax.montecristo.model.application
+
+data class ParsedByteCount(val bytes: Long, val unit: String)
+

--- a/montecristo/src/main/kotlin/com/datastax/montecristo/model/application/YamlConfig.kt
+++ b/montecristo/src/main/kotlin/com/datastax/montecristo/model/application/YamlConfig.kt
@@ -21,7 +21,10 @@ import com.fasterxml.jackson.databind.JsonNode
 import com.fasterxml.jackson.databind.ObjectMapper
 import com.fasterxml.jackson.databind.node.ArrayNode
 
-open class YamlConfig(private val basedata: JsonNode) {
+open class YamlConfig(
+    private val baseData: JsonNode,
+    private val lineNumbers: Map<String, Int> = emptyMap()
+) {
 
     // generic retriever
     fun get(name: String): String {
@@ -40,14 +43,14 @@ open class YamlConfig(private val basedata: JsonNode) {
     // Change the json node into a map object - primarily used in comparison code
     fun asMap(): Map<String, Any> {
         val mapper = ObjectMapper()
-        return mapper.convertValue(basedata, object : TypeReference<Map<String, Any>>() {})
+        return mapper.convertValue(baseData, object : TypeReference<Map<String, Any>>() {})
     }
 
 
     fun getValueFromPath(path: String, default: String): String {
 
         val pathArray = path.split(".")
-        var tempNode = basedata
+        var tempNode = baseData
         pathArray.forEach {
             tempNode = tempNode.path(it)
             // if we get back an array node, this indicates we hit a yaml list (denoted by the dash)
@@ -66,7 +69,7 @@ open class YamlConfig(private val basedata: JsonNode) {
 
     private fun getListValueFromPath(path: String, default: String): String {
         val pathArray = path.split(".")
-        var tempNode = basedata
+        var tempNode = baseData
         pathArray.forEach {
             tempNode = tempNode.path(it)
         }
@@ -85,6 +88,10 @@ open class YamlConfig(private val basedata: JsonNode) {
     }
 
     fun isEmpty(): Boolean {
-        return basedata.isNull || basedata.isEmpty
+        return baseData.isNull || baseData.isEmpty
+    }
+
+    fun lineFor(path: String): Int? {
+        return lineNumbers[path]
     }
 }

--- a/montecristo/src/main/kotlin/com/datastax/montecristo/sections/configuration/CompactionSettings.kt
+++ b/montecristo/src/main/kotlin/com/datastax/montecristo/sections/configuration/CompactionSettings.kt
@@ -16,12 +16,12 @@
 
 package com.datastax.montecristo.sections.configuration
 
+import com.datastax.montecristo.helpers.ByteCountHelper
 import com.datastax.montecristo.helpers.Utils
 import com.datastax.montecristo.logs.Searcher
 import com.datastax.montecristo.model.Cluster
 import com.datastax.montecristo.model.ConfigSource
 import com.datastax.montecristo.model.profiles.ExecutionProfile
-import com.datastax.montecristo.model.versions.cassandra.CassandraV41x
 import com.datastax.montecristo.sections.DocumentSection
 import com.datastax.montecristo.sections.structure.Recommendation
 import com.datastax.montecristo.sections.structure.RecommendationType
@@ -46,39 +46,26 @@ class CompactionSettings : DocumentSection {
         val args = super.createDocArgs(cluster)
         val compactionSection = StringBuilder()
 
-        val compactionThroughput = if (cluster.databaseVersion.hasUnitYamlValues()) {
-            // xxx – 4.1+ clusters might still be using the legacy `compaction_throughput_mb_per_sec`
-            // todo – the handling of the new yaml setting names needs some code redesign/refactoring
-            // the required todo logic here generally repeats for all new yaml setting names, that are annotated with @Replace, like,
-            //     if compaction_throughput, then use it, but parse the units suffix (or assume mb/s and strip it)
-            //     else compaction_throughput_mb_per_sec then use it,
-            //     else use compaction_throughput's default
-            // this would need a call stack like:
-            //  Cluster.getCompactionThroughputYaml() -> Node.getCompactionThroughputYaml() -> DatabaseVersion.getCompactionThroughputYaml()
-            // ref: https://github.com/datastax-labs/Montecristo/pull/14#discussion_r2269403224
-            cluster.getSetting("compaction_throughput", ConfigSource.CASS, "64MiB/s")
-        } else {
-            cluster.getSetting("compaction_throughput_mb_per_sec", ConfigSource.CASS, "16")
-        }
+        val compactionThroughput = cluster.getSetting(ConfigSource.CASS,"compaction_throughput", "64","MiB/s", "compaction_throughput_mb_per_sec",  "16", "MB/s")
+
         val concurrentCompactors = cluster.getSetting("concurrent_compactors", ConfigSource.CASS, "2")
 
         compactionSection.append(Utils.formatCassandraYamlSetting(concurrentCompactors))
         compactionSection.append(Utils.formatCassandraYamlSetting(compactionThroughput))
 
         val concurrentCompactorsValue = concurrentCompactors.getSingleValue().toInt()
-        // hack, assume only "MiB/s" is used on "compaction_throughput"
-        val compactionThroughputValue = compactionThroughput.getSingleValue().replace("MiB/s", "").toInt()
+        val compactionThroughputValue = compactionThroughput.getSingleValue().toLong()
 
-        if (compactionThroughputValue == 0) {
+        if (compactionThroughputValue == 0L) {
             recs.near(RecommendationType.CONFIGURATION, unthrottledThroughputRecommencation)
         } else {
-            if (compactionThroughputValue / concurrentCompactorsValue < 8) {
+            if (compactionThroughputValue / concurrentCompactorsValue < 8_000_000) {
                 compactionSection.append("\n\nThe throughput per compactor is too low : ${(compactionThroughputValue / concurrentCompactorsValue)}MB/s \n")
                 recs.immediate(RecommendationType.CONFIGURATION,throughputPerCompactorRecommendation)
             }
         }
 
-        if (compactionThroughputValue == 16) {
+        if (compactionThroughputValue == 16_000_000L) {
             // This can lead to compaction lagging behind in write heavy/LCS workloads, and the hardware can most probably handle more.
             recs.near(RecommendationType.CONFIGURATION,"""
                 We recommend increasing the value of compaction throughput to 64MB/s, unless Cassandra is running on a single spinning disk.
@@ -86,8 +73,8 @@ class CompactionSettings : DocumentSection {
             """.trimIndent().replace('\n', ' '))
         }
 
-        if (compactionThroughputValue > 200) {
-            recs.near(RecommendationType.CONFIGURATION,"The compaction throughput has been set to $compactionThroughputValue MB/s, which is unusually high. We recommend reviewing the reason that the setting was altered to be this high.")
+        if (compactionThroughputValue > 200_000_000) {
+            recs.near(RecommendationType.CONFIGURATION,"The compaction throughput has been set to ${ByteCountHelper.humanReadableByteCount(compactionThroughputValue)}/s, which is unusually high. We recommend reviewing the reason that the setting was altered to be this high.")
         }
 
         args["compactionSettings"] = compactionSection.toString()

--- a/montecristo/src/test/kotlin/com/datastax/montecristo/fileLoaders/parsers/application/CassandraYamlParserTest.kt
+++ b/montecristo/src/test/kotlin/com/datastax/montecristo/fileLoaders/parsers/application/CassandraYamlParserTest.kt
@@ -16,7 +16,17 @@
 
 package com.datastax.montecristo.fileLoaders.parsers.application
 
+import com.datastax.montecristo.metrics.IMetricServer
+import com.datastax.montecristo.model.Cluster
+import com.datastax.montecristo.model.ConfigSource
+import com.datastax.montecristo.model.LoadError
+import com.datastax.montecristo.model.metrics.BlockedTasks
+import com.datastax.montecristo.model.schema.Schema
+import com.datastax.montecristo.model.versions.DatabaseVersion
+import com.datastax.montecristo.testHelpers.ObjectCreators
+import io.mockk.mockk
 import org.assertj.core.api.Assertions.assertThat
+import org.junit.Assert.assertTrue
 import org.junit.Test
 import java.io.File
 
@@ -27,12 +37,92 @@ internal class CassandraYamlParserTest {
 
         val yamlFile = File(this.javaClass.getResource("/fileLoaders/parsers/application/cassandra.yaml").path)
         val cassandraYaml = CassandraYamlParser.parse(yamlFile)
-        assertThat(cassandraYaml.vNodes).isEqualTo (256)
-        assertThat(cassandraYaml.compactionThroughputLegacy).isEqualTo ("0")
-        assertThat(cassandraYaml.compactionThroughput).isEqualTo ("")
-        assertThat(cassandraYaml.concurrentCompactors).isEqualTo ("") // not set
+        assertThat(cassandraYaml.vNodes).isEqualTo(256)
+        assertThat(cassandraYaml.concurrentCompactors).isEqualTo("") // not set
         assertThat(cassandraYaml.memtableAllocationType).isEqualTo("offheap_objects")
         assertThat(cassandraYaml.seeds).isEqualTo("172.23.24.12, 172.23.24.61")
+        assertThat(cassandraYaml.lineFor("cluster_name")).isEqualTo(12)
+        assertThat(cassandraYaml.lineFor("num_tokens")).isEqualTo(27)
+        assertThat(cassandraYaml.lineFor("seed_provider.parameters.seeds")).isEqualTo(422)
+        assertThat(cassandraYaml.lineFor("setting_that_does_not_exist")).isNull()
     }
 
+    @Test
+    fun testCassandraFileParseRateLimitedLegacyConfigItem() {
+
+        val cassandraYaml = CassandraYamlParser.parse(
+            """
+            compaction_throughput_mb_per_sec: 50
+            """.trimIndent()
+        )
+        val node1 = ObjectCreators.createNode("node1",cassandraYaml = cassandraYaml)
+        val nodelist = listOf(node1)
+        val schema = mockk<Schema>(relaxed = true)
+        val blockedTasks = mockk<BlockedTasks>(relaxed = true)
+        val metricServer = mockk<IMetricServer>(relaxed = true)
+
+        val cluster = Cluster(nodelist, false, false, DatabaseVersion.latest50(), schema, blockedTasks, metricServer, mutableListOf<LoadError>())
+
+        val configRead = cluster.getSetting(ConfigSource.CASS,"compaction_throughput", "64","MiB/s","compaction_throughput_mb_per_sec",  "16", "MB/s")
+
+        assertTrue(configRead.isConsistent())
+        assertThat(configRead.values.size).isEqualTo(1)
+        assertThat(configRead.values.entries.first().value.isSet).isTrue()
+        assertThat(configRead.values.entries.first().value.value.toInt()).isEqualTo(50_000_000)
+        assertThat(configRead.values.entries.first().value.units).isEqualTo("MB")
+    }
+
+    @Test
+    fun testCassandraFileParseRateLegacyAndNewConfigItem() {
+
+        val cassandraYaml = CassandraYamlParser.parse(
+            """
+            compaction_throughput: 25 MiB/s
+            compaction_throughput_mb_per_sec: 50
+            """.trimIndent()
+        )
+        val node1 = ObjectCreators.createNode("node1",cassandraYaml = cassandraYaml)
+        val nodelist = listOf(node1)
+        val schema = mockk<Schema>(relaxed = true)
+        val blockedTasks = mockk<BlockedTasks>(relaxed = true)
+        val metricServer = mockk<IMetricServer>(relaxed = true)
+
+        val cluster = Cluster(nodelist, false, false, DatabaseVersion.latest50(), schema, blockedTasks, metricServer, mutableListOf<LoadError>())
+
+        val configRead = cluster.getSetting(ConfigSource.CASS,"compaction_throughput", "64","MiB/s","compaction_throughput_mb_per_sec",  "16", "MB/s")
+
+        assertTrue(configRead.isConsistent())
+        assertThat(configRead.values.size).isEqualTo(1)
+        assertThat(configRead.values.entries.first().value.isSet).isTrue()
+        assertThat(configRead.values.entries.first().value.value.toInt()).isEqualTo(50_000_000)
+        assertThat(configRead.values.entries.first().value.units).isEqualTo("MB")
+    }
+
+    @Test
+    fun testCassandraFileParseRateLegacyAndNewConfigItemNoUnitSupport() {
+
+        val cassandraYaml = CassandraYamlParser.parse(
+            """
+            compaction_throughput_mb_per_sec: 50
+            compaction_throughput: 25 MiB/s
+ 
+            """.trimIndent()
+        )
+        val node1 = ObjectCreators.createNode("node1",cassandraYaml = cassandraYaml)
+        val nodelist = listOf(node1)
+        val schema = mockk<Schema>(relaxed = true)
+        val blockedTasks = mockk<BlockedTasks>(relaxed = true)
+        val metricServer = mockk<IMetricServer>(relaxed = true)
+
+        val cluster = Cluster(nodelist, false, false, DatabaseVersion.latest311(), schema, blockedTasks, metricServer, mutableListOf<LoadError>())
+
+        val configRead = cluster.getSetting(ConfigSource.CASS,"compaction_throughput", "64","MiB/s","compaction_throughput_mb_per_sec",  "16", "MB/s")
+
+        // even though the 25 is the last value, the DB doesn't support that format so it should be ignored.
+        assertTrue(configRead.isConsistent())
+        assertThat(configRead.values.size).isEqualTo(1)
+        assertThat(configRead.values.entries.first().value.isSet).isTrue()
+        assertThat(configRead.values.entries.first().value.value.toInt()).isEqualTo(50_000_000)
+        assertThat(configRead.values.entries.first().value.units).isEqualTo("MB")
+    }
 }

--- a/montecristo/src/test/kotlin/com/datastax/montecristo/helpers/ByteCountHelperTest.kt
+++ b/montecristo/src/test/kotlin/com/datastax/montecristo/helpers/ByteCountHelperTest.kt
@@ -16,6 +16,7 @@
 
 package com.datastax.montecristo.helpers
 
+import com.datastax.montecristo.model.application.ParsedByteCount
 import org.junit.Test
 import java.util.*
 import kotlin.test.assertEquals
@@ -23,7 +24,7 @@ import kotlin.test.assertEquals
 internal class ByteCountHelperTest {
     @Test
     fun testHumanReadableByteCountSiUnits() {
-        Locale.setDefault(Locale.ENGLISH);
+        Locale.setDefault(Locale.ENGLISH)
 
         val units = ByteCountHelperUnits.SI
 
@@ -38,7 +39,7 @@ internal class ByteCountHelperTest {
 
     @Test
     fun testHumanReadableByteCountBinaryUnits() {
-        Locale.setDefault(Locale.ENGLISH);
+        Locale.setDefault(Locale.ENGLISH)
 
         val units = ByteCountHelperUnits.BINARY
 
@@ -71,5 +72,37 @@ internal class ByteCountHelperTest {
         assertEquals(8_000_000_000, ByteCountHelper.parseHumanReadableByteCountToLong("8 GB"))
         assertEquals(32_000, ByteCountHelper.parseHumanReadableByteCountToLong("32 KB"))
         assertEquals(32_000_000, ByteCountHelper.parseHumanReadableByteCountToLong("32000kB"))
+    }
+
+    @Test
+    fun testParseByteCountWithRateSiUnits() {
+        // Test SI units with /s suffix
+        assertEquals(ParsedByteCount(8_000_000_000, "GB"), ByteCountHelper.parseByteCountWithRate("8 GB/s"))
+        assertEquals(ParsedByteCount(8_000_000_000, "GB"), ByteCountHelper.parseByteCountWithRate("8GB/s"))
+        assertEquals(ParsedByteCount(32_000, "KB"), ByteCountHelper.parseByteCountWithRate("32 KB/s"))
+        assertEquals(ParsedByteCount(32_000_000_000, "MB"), ByteCountHelper.parseByteCountWithRate("32000 MB/s"))
+
+        // Test with /sec suffix
+        assertEquals(ParsedByteCount(8_000_000_000, "GB"), ByteCountHelper.parseByteCountWithRate("8 GB/sec"))
+        assertEquals(ParsedByteCount(32_000, "KB"), ByteCountHelper.parseByteCountWithRate("32KB/sec"))
+    }
+
+    @Test
+    fun testParseByteCountWithRateBinaryUnits() {
+        // Test binary units with /s suffix
+        assertEquals(ParsedByteCount(8_589_934_592, "GiB"), ByteCountHelper.parseByteCountWithRate("8 GiB/s"))
+        assertEquals(ParsedByteCount(8_589_934_592, "GiB"), ByteCountHelper.parseByteCountWithRate("8GiB/s"))
+        assertEquals(ParsedByteCount(32_657_530_880, "KiB"), ByteCountHelper.parseByteCountWithRate("31892120 KiB/s"))
+
+        // Test with /sec suffix
+        assertEquals(ParsedByteCount(1_099_511_627_776, "TiB"), ByteCountHelper.parseByteCountWithRate("1 TiB/sec"))
+    }
+
+    @Test
+    fun testParseByteCountWithRateInvalidInput() {
+        // Test invalid inputs return null
+        assertEquals(ParsedByteCount(-1, "Invalid format"), ByteCountHelper.parseByteCountWithRate("invalid"))
+        assertEquals(ParsedByteCount(-1, "Invalid format"), ByteCountHelper.parseByteCountWithRate("1.0 QB/s"))
+        assertEquals(ParsedByteCount(-1, "Invalid format"), ByteCountHelper.parseByteCountWithRate(""))
     }
 }

--- a/montecristo/src/test/kotlin/com/datastax/montecristo/sections/configuration/CompactionSettingsTest.kt
+++ b/montecristo/src/test/kotlin/com/datastax/montecristo/sections/configuration/CompactionSettingsTest.kt
@@ -16,15 +16,18 @@
 
 package com.datastax.montecristo.sections.configuration
 
+import com.datastax.montecristo.fileLoaders.parsers.application.CassandraYamlParser
 import com.datastax.montecristo.logs.Searcher
+import com.datastax.montecristo.metrics.IMetricServer
 import com.datastax.montecristo.model.Cluster
-import com.datastax.montecristo.model.ConfigSource
-import com.datastax.montecristo.model.application.ConfigValue
-import com.datastax.montecristo.model.application.ConfigurationSetting
+import com.datastax.montecristo.model.LoadError
+import com.datastax.montecristo.model.metrics.BlockedTasks
 import com.datastax.montecristo.model.profiles.ExecutionProfile
+import com.datastax.montecristo.model.schema.Schema
+import com.datastax.montecristo.model.versions.DatabaseVersion
 import com.datastax.montecristo.sections.structure.Recommendation
 import com.datastax.montecristo.sections.structure.RecommendationPriority
-import io.mockk.every
+import com.datastax.montecristo.testHelpers.ObjectCreators
 import io.mockk.mockk
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.Test
@@ -33,14 +36,20 @@ internal class CompactionSettingsTest {
 
     @Test
     fun getDocumentNoRecsValues() {
-
-        val compactorConfigSetting = ConfigurationSetting("compaction_throughput_mb_per_sec", mapOf(Pair("node1", ConfigValue(true, "16","128"))))
-        val concurrentConfigSetting = ConfigurationSetting("concurrent_compactors", mapOf(Pair("node1", ConfigValue(true, "2","16"))))
+        val cassandraYaml = CassandraYamlParser.parse(
+            """
+            compaction_throughput_mb_per_sec: 128
+            concurrent_compactors: 16
+ 
+            """.trimIndent()
+        )
+        val node1 = ObjectCreators.createNode("node1",cassandraYaml = cassandraYaml)
+        val nodelist = listOf(node1)
+        val schema = mockk<Schema>(relaxed = true)
+        val blockedTasks = mockk<BlockedTasks>(relaxed = true)
+        val metricServer = mockk<IMetricServer>(relaxed = true)
         val searcher = mockk<Searcher>(relaxed = true)
-        val cluster = mockk<Cluster>(relaxed = true)
-        every { cluster.getSetting("compaction_throughput_mb_per_sec", ConfigSource.CASS, "16") } returns compactorConfigSetting
-        every { cluster.getSetting("concurrent_compactors", ConfigSource.CASS, "2") } returns concurrentConfigSetting
-
+        val cluster = Cluster(nodelist, false, false, DatabaseVersion.latest311(), schema, blockedTasks, metricServer, mutableListOf<LoadError>())
         val compactor = CompactionSettings()
         val recs: MutableList<Recommendation> = mutableListOf()
 
@@ -52,14 +61,20 @@ internal class CompactionSettingsTest {
 
     @Test
     fun getDocumentLowThroughputPerCompactorValues() {
-
-        val compactorConfigSetting = ConfigurationSetting("compaction_throughput_mb_per_sec", mapOf(Pair("node1", ConfigValue(true, "16","100"))))
-        val concurrentConfigSetting = ConfigurationSetting("concurrent_compactors", mapOf(Pair("node1", ConfigValue(true, "2","16"))))
+        val cassandraYaml = CassandraYamlParser.parse(
+            """
+            compaction_throughput_mb_per_sec: 100
+            concurrent_compactors: 16
+ 
+            """.trimIndent()
+        )
+        val node1 = ObjectCreators.createNode("node1",cassandraYaml = cassandraYaml)
+        val nodelist = listOf(node1)
+        val schema = mockk<Schema>(relaxed = true)
+        val blockedTasks = mockk<BlockedTasks>(relaxed = true)
+        val metricServer = mockk<IMetricServer>(relaxed = true)
         val searcher = mockk<Searcher>(relaxed = true)
-        val cluster = mockk<Cluster>(relaxed = true)
-        every { cluster.getSetting("compaction_throughput_mb_per_sec", ConfigSource.CASS, "16") } returns compactorConfigSetting
-        every { cluster.getSetting("concurrent_compactors", ConfigSource.CASS, "2") } returns concurrentConfigSetting
-
+        val cluster = Cluster(nodelist, false, false, DatabaseVersion.latest311(), schema, blockedTasks, metricServer, mutableListOf<LoadError>())
         val compactor = CompactionSettings()
         val recs: MutableList<Recommendation> = mutableListOf()
 
@@ -73,13 +88,20 @@ internal class CompactionSettingsTest {
 
     @Test
     fun getDocumentDefaultCompactionsMb() {
-        val compactorConfigSetting = ConfigurationSetting("compaction_throughput_mb_per_sec", mapOf(Pair("node1", ConfigValue(true, "16","16"))))
-        val concurrentConfigSetting = ConfigurationSetting("concurrent_compactors", mapOf(Pair("node1", ConfigValue(true, "2","2"))))
+        val cassandraYaml = CassandraYamlParser.parse(
+            """
+            compaction_throughput_mb_per_sec: 16
+            concurrent_compactors: 2
+ 
+            """.trimIndent()
+        )
+        val node1 = ObjectCreators.createNode("node1",cassandraYaml = cassandraYaml)
+        val nodelist = listOf(node1)
+        val schema = mockk<Schema>(relaxed = true)
+        val blockedTasks = mockk<BlockedTasks>(relaxed = true)
+        val metricServer = mockk<IMetricServer>(relaxed = true)
         val searcher = mockk<Searcher>(relaxed = true)
-        val cluster = mockk<Cluster>(relaxed = true)
-        every { cluster.getSetting("compaction_throughput_mb_per_sec", ConfigSource.CASS, "16") } returns compactorConfigSetting
-        every { cluster.getSetting("concurrent_compactors", ConfigSource.CASS, "2") } returns concurrentConfigSetting
-
+        val cluster = Cluster(nodelist, false, false, DatabaseVersion.latest311(), schema, blockedTasks, metricServer, mutableListOf<LoadError>())
         val compactor = CompactionSettings()
         val recs: MutableList<Recommendation> = mutableListOf()
 
@@ -93,14 +115,20 @@ internal class CompactionSettingsTest {
 
     @Test
     fun getDocumentUnthrottledCompactionsMb() {
-
-        val compactorConfigSetting = ConfigurationSetting("compaction_throughput_mb_per_sec", mapOf(Pair("node1", ConfigValue(true, "16","0"))))
-        val concurrentConfigSetting = ConfigurationSetting("concurrent_compactors", mapOf(Pair("node1",ConfigValue(true, "2", "2"))))
+        val cassandraYaml = CassandraYamlParser.parse(
+            """
+            compaction_throughput_mb_per_sec: 0
+            concurrent_compactors: 2
+ 
+            """.trimIndent()
+        )
+        val node1 = ObjectCreators.createNode("node1",cassandraYaml = cassandraYaml)
+        val nodelist = listOf(node1)
+        val schema = mockk<Schema>(relaxed = true)
+        val blockedTasks = mockk<BlockedTasks>(relaxed = true)
+        val metricServer = mockk<IMetricServer>(relaxed = true)
         val searcher = mockk<Searcher>(relaxed = true)
-        val cluster = mockk<Cluster>(relaxed = true)
-        every { cluster.getSetting("compaction_throughput_mb_per_sec", ConfigSource.CASS, "16") } returns compactorConfigSetting
-        every { cluster.getSetting("concurrent_compactors", ConfigSource.CASS, "2") } returns concurrentConfigSetting
-
+        val cluster = Cluster(nodelist, false, false, DatabaseVersion.latest311(), schema, blockedTasks, metricServer, mutableListOf<LoadError>())
         val compactor = CompactionSettings()
         val recs: MutableList<Recommendation> = mutableListOf()
 
@@ -115,21 +143,57 @@ internal class CompactionSettingsTest {
     @Test
     fun getDocumentVeryHighCompactionsMb() {
 
-        val compactorConfigSetting = ConfigurationSetting("compaction_throughput_mb_per_sec", mapOf(Pair("node1",ConfigValue(true, "16", "400"))))
-        val concurrentConfigSetting = ConfigurationSetting("concurrent_compactors", mapOf(Pair("node1", ConfigValue(true, "2","2"))))
+        val cassandraYaml = CassandraYamlParser.parse(
+            """
+            compaction_throughput_mb_per_sec: 400
+            concurrent_compactors: 2
+ 
+            """.trimIndent()
+        )
+        val node1 = ObjectCreators.createNode("node1",cassandraYaml = cassandraYaml)
+        val nodelist = listOf(node1)
+        val schema = mockk<Schema>(relaxed = true)
+        val blockedTasks = mockk<BlockedTasks>(relaxed = true)
+        val metricServer = mockk<IMetricServer>(relaxed = true)
         val searcher = mockk<Searcher>(relaxed = true)
-        val cluster = mockk<Cluster>(relaxed = true)
-        every { cluster.getSetting("compaction_throughput_mb_per_sec", ConfigSource.CASS, "16") } returns compactorConfigSetting
-        every { cluster.getSetting("concurrent_compactors", ConfigSource.CASS, "2") } returns concurrentConfigSetting
-
+        val cluster = Cluster(nodelist, false, false, DatabaseVersion.latest311(), schema, blockedTasks, metricServer, mutableListOf<LoadError>())
         val compactor = CompactionSettings()
         val recs: MutableList<Recommendation> = mutableListOf()
 
         val template = compactor.getDocument(cluster, searcher, recs, ExecutionProfile.default())
         assertThat(recs.size).isEqualTo(1)
         assertThat(recs[0].priority).isEqualTo(RecommendationPriority.NEAR)
-        assertThat(recs[0].longForm).isEqualTo("The compaction throughput has been set to 400 MB/s, which is unusually high. We recommend reviewing the reason that the setting was altered to be this high.")
+        assertThat(recs[0].longForm).isEqualTo("The compaction throughput has been set to 400.0 MB/s, which is unusually high. We recommend reviewing the reason that the setting was altered to be this high.")
         assertThat(template).contains("concurrent_compactors: 2")
         assertThat(template).contains("compaction_throughput_mb_per_sec: 400")
+    }
+
+
+    @Test
+    fun getDocumentVeryHighCompactionsMbNewYamlSetting() {
+
+        val cassandraYaml = CassandraYamlParser.parse(
+            """
+            compaction_throughput: 400MB/s
+            concurrent_compactors: 2
+ 
+            """.trimIndent()
+        )
+        val node1 = ObjectCreators.createNode("node1",cassandraYaml = cassandraYaml)
+        val nodelist = listOf(node1)
+        val schema = mockk<Schema>(relaxed = true)
+        val blockedTasks = mockk<BlockedTasks>(relaxed = true)
+        val metricServer = mockk<IMetricServer>(relaxed = true)
+        val searcher = mockk<Searcher>(relaxed = true)
+        val cluster = Cluster(nodelist, false, false, DatabaseVersion.latest50(), schema, blockedTasks, metricServer, mutableListOf<LoadError>())
+        val compactor = CompactionSettings()
+        val recs: MutableList<Recommendation> = mutableListOf()
+
+        val template = compactor.getDocument(cluster, searcher, recs, ExecutionProfile.default())
+        assertThat(recs.size).isEqualTo(1)
+        assertThat(recs[0].priority).isEqualTo(RecommendationPriority.NEAR)
+        assertThat(recs[0].longForm).isEqualTo("The compaction throughput has been set to 400.0 MB/s, which is unusually high. We recommend reviewing the reason that the setting was altered to be this high.")
+        assertThat(template).contains("concurrent_compactors: 2")
+        assertThat(template).contains("compaction_throughput: 400")
     }
 }


### PR DESCRIPTION
It also accounts for a last setting wins when old + new settings are used. CompactionSettings section is swapped to the new mechanism to demonstrate how it would work. when the setting has some form of units, it always then should check values in raw numbers e.g. bytes. This mechanism I believe would also support non unit name changes. I did consider pushing the name into the version objects, but in reality it becomes a list of names of 1 or more entries and gets messy. The downside to this approach taken is it only supports 2 names for any setting, current + legacy.